### PR TITLE
CAM-51 - Alert out of date browser version

### DIFF
--- a/edx-platform/israelxedu.gov.il/lms/static/sass/_overrides.scss
+++ b/edx-platform/israelxedu.gov.il/lms/static/sass/_overrides.scss
@@ -205,6 +205,41 @@ h1, h2, h3, h4, h5, h6{
   }
 }
 
+//Alert browser
+.buorg {
+  background-position: 8px 17px;
+  position:absolute;
+  position:fixed;
+  z-index:111111;
+  width:100%;
+  top:0px;
+  left:0px;
+  border-bottom:1px solid #A29330;
+  cursor:pointer;
+  background-color: $browser-update-background;
+  font: 17px Calibri,Helvetica,Arial,sans-serif;
+  box-shadow: 0 0 5px rgba(0,0,0,0.2);
+
+  #buorgul{
+    background-color: $browser-update-ok-button;
+  }
+
+  #buorgig{
+   background-color: $browser-update-ignore-button;
+  }
+
+}
+
+@media only screen and (max-width: 700px){
+.buorg div {
+  padding:5px 12px 5px 9px; 
+  text-indent: 22px;
+  line-height: 1.3em;
+}
+.buorg {
+  background-position: 9px 8px;}
+}
+
 //Modals
 .modal {
   border-radius: 0px !important;

--- a/edx-platform/israelxedu.gov.il/lms/static/sass/base/_variables.scss
+++ b/edx-platform/israelxedu.gov.il/lms/static/sass/base/_variables.scss
@@ -29,3 +29,7 @@ $tablet:            768px;
 $desktop:           1024px;
 $desktop-xl:        1280px;
 
+//Alert browser out of date
+$browser-update-background: $header-graphic-super-color !important;
+$browser-update-ok-button: $button-color;
+$browser-update-ignore-button: $action-primary-disabled-bg;

--- a/edx-platform/israelxedu.gov.il/lms/templates/header.html
+++ b/edx-platform/israelxedu.gov.il/lms/templates/header.html
@@ -6,7 +6,25 @@ from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
+
+% if configuration_helpers.get_value('ENABLE_UNSUPPORTED_BROWSER_ALERT', settings.FEATURES.get('ENABLE_UNSUPPORTED_BROWSER_ALERT', True)):
+  <script>
+  var $buoop = {notify:${configuration_helpers.get_value('UNSUPPORTED_BROWSER_ALERT_VERSIONS', settings.FEATURES.get('UNSUPPORTED_BROWSER_ALERT_VERSIONS', "{i:-3,f:-3,o:-3,s:-3,c:-3}"))|h},
+    insecure:true,
+    api:5,
+    l:"${LANGUAGE_CODE}",
+    reminder:0};
+  function $buo_f(){
+   var e = document.createElement("script");
+   e.src = "//browser-update.org/update.min.js";
+   document.body.appendChild(e);
+  };
+  try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
+  catch(e){window.attachEvent("onload", $buo_f)}
+  </script>
+% endif
 
 
 <header id="global-navigation" class="header-main" >


### PR DESCRIPTION
## CAM-51

### Description

This PR adds the Browser-Update script to notify the user when their browsers are out of date.

According to the screenshot of the conversation in Jira, the script it's configured to 3 versions backward of IE/Edge, Chrome, Firefox, Opera, and Safari.

The parameter `insecure` could generate confusion, but that's means to alert the user when their browser has security issues.

Browser-Update has an advanced configuration where we can set up CSS and texts. But since we don't have any mockup we proceed with the default script.

### How to test it

1. You'll need to download an old version of your browser or simply you could add the parameter `test:true` in the JS

2. Set the flag `ENABLE_UNSUPPORTED_BROWSER_ALERT` to True in settings or site_configurations.

3. Optionally set the flag `UNSUPPORTED_BROWSER_ALERT_VERSIONS` in settings or site_configurations with this string: `{i:-3,f:-3,o:-3,s:-3,c:-3}` where the single letter means the browser's name and the integer mean the backward version you want to check. Or if you want to alert the user any out of date version just set -0.01. The default value is 3 backward version for all browsers.

After that, you'll see an alert displayed.

### Screenshots

![screenshot from 2018-02-13 17-44-47](https://user-images.githubusercontent.com/3374009/36178063-ba956b46-10e5-11e8-9ea2-73a60820c795.png)

### Reviewers

- [ ] @felipemontoya 
- [ ] @jagonzalr 